### PR TITLE
Define xrange() for Python 3

### DIFF
--- a/utils/provider.py
+++ b/utils/provider.py
@@ -3,6 +3,11 @@ import sys
 import numpy as np
 import h5py
 
+try:
+  xrange
+except NameError:
+  xrange = range
+
 def shuffle_data(data, labels):
   """ Shuffle data and labels.
     Input:


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of a reworked version of __range()__.